### PR TITLE
Clearer Tracing

### DIFF
--- a/chrome/bin/lib/log.js
+++ b/chrome/bin/lib/log.js
@@ -171,7 +171,7 @@
         caller = this.trace;
       }
       if (loggable(this.TRACE)) {
-        return console.log(new this.StackTrace(caller).stack);
+        return console.log(new this.Trace(caller).stack);
       }
     };
 
@@ -192,18 +192,19 @@
 
   })(utils.Class));
 
-  log.StackTrace = (function(_super) {
+  log.Trace = (function(_super) {
 
-    __extends(StackTrace, _super);
+    __extends(Trace, _super);
 
-    function StackTrace(caller) {
+    function Trace(caller) {
       if (caller == null) {
-        caller = log.StackTrace;
+        caller = log.Trace;
       }
       Error.captureStackTrace(this, caller);
+      this.stack = this.stack.replace(/^Error/, 'Trace');
     }
 
-    return StackTrace;
+    return Trace;
 
   })(utils.Class);
 

--- a/chrome/src/lib/log.coffee
+++ b/chrome/src/lib/log.coffee
@@ -94,7 +94,7 @@ log = window.log = new class Log extends utils.Class
 
   # Output a stack trace.
   trace: (caller = @trace) ->
-    console.log new @StackTrace(caller).stack if loggable @TRACE
+    console.log new @Trace(caller).stack if loggable @TRACE
 
   # Output all warning `entries`.
   warn: (entries...) ->
@@ -103,14 +103,15 @@ log = window.log = new class Log extends utils.Class
 # Public classes
 # --------------
 
-# `StackTrace` allows the current stack trace to be retrieved in the easiest
-# way possible.
-class log.StackTrace extends utils.Class
+# `Trace` allows the current stack trace to be retrieved in the easiest way
+# possible.
+class log.Trace extends utils.Class
 
-  # Create a new instance of `StackTrace` for the `caller`.
-  constructor: (caller = log.StackTrace) ->
+  # Create a new instance of `Trace` for the `caller`.
+  constructor: (caller = log.Trace) ->
     # Create the stack trace and assign it to a new `stack` property.
     Error.captureStackTrace this, caller
+    @stack = @stack.replace /^Error/, 'Trace'
 
 # Configuration
 # -------------


### PR DESCRIPTION
Trace logging similar to the following;

```
Error
    at isProtectedPage (chrome-extension://dcjnfaoifoefmnbhhlbppaebgnccfddf/lib/background.js:460:9)
    at Object.callback (chrome-extension://dcjnfaoifoefmnbhhlbppaebgnccfddf/lib/background.js:346:20)
    at Object.chromeHidden.handleResponse (sendRequest:49:24)
```

Can be confusing because of the "Error" heading. This PR replaces this heading with "Trace". For example;

```
Trace
    at isProtectedPage (chrome-extension://dcjnfaoifoefmnbhhlbppaebgnccfddf/lib/background.js:460:9)
    at Object.callback (chrome-extension://dcjnfaoifoefmnbhhlbppaebgnccfddf/lib/background.js:346:20)
    at Object.chromeHidden.handleResponse (sendRequest:49:24)
```

Simple change but effective.
