### PR TITLE
Fix OS X keyboard shortcut modifiers

### DIFF
--- a/chrome/bin/lib/background.js
+++ b/chrome/bin/lib/background.js
@@ -2197,7 +2197,7 @@
 
     Extension.prototype.isThisPlatform = function(os) {
       log.trace();
-      return __indexOf.call(navigator.userAgent.toLowerCase(), os) >= 0;
+      return RegExp("" + os, "i").test(navigator.platform);
     };
 
     Extension.prototype.modifiers = function() {

--- a/chrome/src/lib/background.coffee
+++ b/chrome/src/lib/background.coffee
@@ -1840,7 +1840,7 @@ ext = window.ext = new class Extension extends utils.Class
   isThisPlatform: (os) ->
     log.trace()
 
-    os in navigator.userAgent.toLowerCase()
+    /// #{os} ///i.test navigator.platform
 
   # Retrieve the correct string representation of the keyboard modifiers for the user's operating
   # system.


### PR DESCRIPTION
This PR fixes the problem detailed by #168 by fixing the logic of the `ext.isThisPlatform` method which is used to identify the user's OS.
