### PR TITLE
Linux bug fix

### DIFF
--- a/chrome/bin/lib/background.js
+++ b/chrome/bin/lib/background.js
@@ -2220,8 +2220,8 @@
             type: 'toolbar'
           });
         });
-        chrome.runtime.onMessage.addListener(onMessage);
-        chrome.runtime.onMessageExternal.addListener(onMessageExternal);
+        chrome.extension.onMessage.addListener(onMessage);
+        chrome.extension.onMessageExternal.addListener(onMessageExternal);
         browser.version = getBrowserVersion();
         operatingSystem = getOperatingSystem();
         if (isNewInstall) {

--- a/chrome/bin/lib/content.js
+++ b/chrome/bin/lib/content.js
@@ -108,7 +108,7 @@
     return node.value = str;
   };
 
-  chrome.runtime.sendMessage({
+  chrome.extension.sendMessage({
     type: 'info'
   }, function(data) {
     var isMac;
@@ -137,7 +137,7 @@
         key = String.fromCharCode(e.keyCode).toUpperCase();
         if (__indexOf.call(hotkeys, key) >= 0) {
           elements.field = (_ref = e.target.nodeName) === 'INPUT' || _ref === 'TEXTAREA' ? e.target : null;
-          chrome.runtime.sendMessage({
+          chrome.extension.sendMessage({
             data: {
               key: key
             },
@@ -147,7 +147,7 @@
         }
       }
     });
-    return chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    return chrome.extension.onMessage.addListener(function(message, sender, sendResponse) {
       var callback, container, contents, href, images, info, key, link, links, node, nodes, result, selection, src, _i, _j, _k, _len, _len1, _len2, _ref, _ref1, _ref2, _ref3;
 
       callback = function() {

--- a/chrome/bin/lib/install.js
+++ b/chrome/bin/lib/install.js
@@ -4,7 +4,7 @@
 // For all details and documentation:
 // <http://neocotic.com/template>
 (function() {
-  chrome.runtime.sendMessage({
+  chrome.extension.sendMessage({
     type: 'info'
   }, function(data) {
     var cls, link, newClasses, oldClasses, _i, _j, _len, _len1, _ref, _results;

--- a/chrome/bin/lib/popup.js
+++ b/chrome/bin/lib/popup.js
@@ -21,7 +21,7 @@
       type: this.getAttribute('data-type')
     };
     log.debug('Sending the following message to the extension controller', message);
-    return chrome.runtime.sendMessage(message);
+    return chrome.extension.sendMessage(message);
   };
 
   popup = window.popup = new (Popup = (function(_super) {

--- a/chrome/bin/lib/utils.js
+++ b/chrome/bin/lib/utils.js
@@ -163,7 +163,7 @@
     Utils.prototype.url = function() {
       var _ref1;
 
-      return (_ref1 = chrome.runtime).getURL.apply(_ref1, arguments);
+      return (_ref1 = chrome.extension).getURL.apply(_ref1, arguments);
     };
 
     return Utils;

--- a/chrome/src/lib/background.coffee
+++ b/chrome/src/lib/background.coffee
@@ -1859,8 +1859,8 @@ ext = window.ext = new class Extension extends utils.Class
           data: key: store.get 'toolbar.key'
           type: 'toolbar'
       # Add listeners for internal and external messages.
-      chrome.runtime.onMessage.addListener onMessage
-      chrome.runtime.onMessageExternal.addListener onMessageExternal
+      chrome.extension.onMessage.addListener onMessage
+      chrome.extension.onMessageExternal.addListener onMessageExternal
 
       # Derive the browser and OS information.
       browser.version = do getBrowserVersion

--- a/chrome/src/lib/content.coffee
+++ b/chrome/src/lib/content.coffee
@@ -84,7 +84,7 @@ paste = (node, value) ->
 
 # Wrap the function functionality in a message for Template's extension ID and current version so
 # that it can be used to detect previous injections.
-chrome.runtime.sendMessage type: 'info', (data) ->
+chrome.extension.sendMessage type: 'info', (data) ->
   hotkeys = data.hotkeys
   isMac   = navigator.userAgent.toLowerCase().indexOf('mac') isnt -1
 
@@ -108,14 +108,14 @@ chrome.runtime.sendMessage type: 'info', (data) ->
       if key in hotkeys
         elements.field = if e.target.nodeName in ['INPUT', 'TEXTAREA'] then e.target else null
 
-        chrome.runtime.sendMessage
+        chrome.extension.sendMessage
           data: key: key
           type: 'shortcut'
         e.preventDefault()
 
   # Add a listener to provide the background page with information that is extracted from the DOM
   # or perform auto-paste functionality.
-  chrome.runtime.onMessage.addListener (message, sender, sendResponse) ->
+  chrome.extension.onMessage.addListener (message, sender, sendResponse) ->
     # Safely handle callback functionality.
     callback = (args...) ->
       if typeof sendResponse is 'function'

--- a/chrome/src/lib/install.coffee
+++ b/chrome/src/lib/install.coffee
@@ -8,7 +8,7 @@
 # -------------
 
 # Wrap the functionality in a message for Template's details in order to get the ID in use.
-chrome.runtime.sendMessage type: 'info', (data) ->
+chrome.extension.sendMessage type: 'info', (data) ->
   # Names of the classes to be added to the targeted elements.
   newClasses = ['disabled']
   # Names of the classes to be removed from the targeted elements.

--- a/chrome/src/lib/popup.coffee
+++ b/chrome/src/lib/popup.coffee
@@ -22,7 +22,7 @@ sendMessage = ->
     type: @getAttribute 'data-type'
 
   log.debug 'Sending the following message to the extension controller', message
-  chrome.runtime.sendMessage message
+  chrome.extension.sendMessage message
 
 # Popup page setup
 # ----------------

--- a/chrome/src/lib/utils.coffee
+++ b/chrome/src/lib/utils.coffee
@@ -108,9 +108,9 @@ utils = window.utils = new class Utils extends Class
   trimToUpper: (str = '') ->
     str.trim().toUpperCase()
 
-  # Convenient shorthand for `chrome.runtime.getURL`.
+  # Convenient shorthand for `chrome.extension.getURL`.
   url: ->
-    chrome.runtime.getURL arguments...
+    chrome.extension.getURL arguments...
 
 # Public classes
 # --------------


### PR DESCRIPTION
Fixed a bug where, for some reason (I can find no documentation), the [chrome.runtime](http://developer.chrome.com/extensions/runtime.html) API on linux systems does **not** have the methods required for [message passing](http://developer.chrome.com/extensions/messaging.html) while Windows and OS X do not share this problem.

All relevant method references have been changed to their old (now deprecated) references on the [chrome.extension](http://developer.chrome.com/extensions/extension.html) API for cross-platform compatibility.
