### PR TITLE
XPath

### DIFF
--- a/chrome/bin/_locales/en/messages.json
+++ b/chrome/bin/_locales/en/messages.json
@@ -867,7 +867,7 @@
         "content": "</a>",
         "example": "</a>"
       },
-      "o_link_selectors": {
+      "o_link_xpath": {
         "content": "<a href=\"http://www.w3.org/TR/xpath/\" target=\"_blank\">",
         "example": "<a href=\"http://www.w3.org/TR/xpath/\">"
       }
@@ -2162,7 +2162,7 @@
     "description": "Description of the upperCase variable on the Guide tab of the Options page under the Operations section."
   },
   "opt_guide_operations_xpath_all_html_text": {
-    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all results for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathAllHTML variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_abbr": {
@@ -2188,7 +2188,7 @@
     }
   },
   "opt_guide_operations_xpath_all_markdown_text": {
-    "message": "Concatenate the contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "message": "Concatenate the contents of all results for the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
     "description": "Description of the xpathAllMarkdown variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2206,7 +2206,7 @@
     }
   },
   "opt_guide_operations_xpath_all_text": {
-    "message": "Concatenate the text of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Concatenate all results for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathAll variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2220,7 +2220,7 @@
     }
   },
   "opt_guide_operations_xpath_html_text": {
-    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathHTML variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_abbr": {
@@ -2246,7 +2246,7 @@
     }
   },
   "opt_guide_operations_xpath_markdown_text": {
-    "message": "Get the contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "message": "Get the contents of the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
     "description": "Description of the xpathMarkdown variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2264,7 +2264,7 @@
     }
   },
   "opt_guide_operations_xpath_text": {
-    "message": "Get the text of first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Get the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression as text",
     "description": "Description of the xpath variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -3963,6 +3963,10 @@
     "message": "An error occurred while collecting information",
     "description": "Notification for when something went wrong while collecting contextual data before processing a template."
   },
+  "result_bad_expression_description": {
+    "message": "There was a problem parsing an expression.",
+    "description": "Notification for when an error occurs when parsing CSS selector or XPath expressions while processing a template."
+  },
   "result_bad_template_description": {
     "message": "An error occurred while deriving the activated template",
     "description": "Notification for when no active template can be derived from the current context."
@@ -3971,17 +3975,13 @@
     "message": "An error occurred while requesting information",
     "description": "Notification for when an invalid type was used by the requesting message."
   },
-  "result_bad_uri_description": {
-    "message": "The URL is not properly encoded",
-    "description": "Notification for when collecting data for an invalid URL before processing a template."
-  },
   "result_bad_title": {
     "message": "Sorry!",
     "description": "Notification header for when something bad happened while processing a template."
   },
-  "result_bad_xpath_description": {
-    "message": "There was a problem parsing an XPath expression.",
-    "description": "Notification for when an error occurs when parsing XPath expressions while processing a template."
+  "result_bad_uri_description": {
+    "message": "The URL is not properly encoded",
+    "description": "Notification for when collecting data for an invalid URL before processing a template."
   },
   "result_good_description": {
     "message": "$TEMPLATE$ has been copied",

--- a/chrome/bin/_locales/en/messages.json
+++ b/chrome/bin/_locales/en/messages.json
@@ -859,6 +859,20 @@
       }
     }
   },
+  "opt_guide_definitions_footer_4": {
+    "message": "Learn more about the $O_LINK_XPATH$XPath API$C_LINK$",
+    "description": "Fourth optional footer displayed below Definitions tables.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_selectors": {
+        "content": "<a href=\"http://www.w3.org/TR/xpath/\" target=\"_blank\">",
+        "example": "<a href=\"http://www.w3.org/TR/xpath/\">"
+      }
+    }
+  },
   "opt_guide_description_header": {
     "message": "Description",
     "description": "Header for the Description column."
@@ -2146,6 +2160,122 @@
   "opt_guide_operations_upper_case_text": {
     "message": "Transform the text provided into upper case",
     "description": "Description of the upperCase variable on the Guide tab of the Options page under the Operations section."
+  },
+  "opt_guide_operations_xpath_all_html_text": {
+    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathAllHTML variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_abbr": {
+        "content": "</abbr>",
+        "example": "</abbr>"
+      },
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_abbr_1": {
+        "content": "<abbr title=\"",
+        "example": "<abbr title=\""
+      },
+      "o_abbr_2": {
+        "content": "\">",
+        "example": "\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_all_markdown_text": {
+    "message": "Concatenate the contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "description": "Description of the xpathAllMarkdown variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_markdown": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/Markdown\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/Markdown\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_all_text": {
+    "message": "Concatenate the text of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathAll variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_html_text": {
+    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathHTML variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_abbr": {
+        "content": "</abbr>",
+        "example": "</abbr>"
+      },
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_abbr_1": {
+        "content": "<abbr title=\"",
+        "example": "<abbr title=\""
+      },
+      "o_abbr_2": {
+        "content": "\">",
+        "example": "\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_markdown_text": {
+    "message": "Get the contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "description": "Description of the xpathMarkdown variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_markdown": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/Markdown\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/Markdown\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_text": {
+    "message": "Get the text of first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpath variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
   },
   "opt_guide_options_header": {
     "message": "Options",
@@ -3848,6 +3978,10 @@
   "result_bad_title": {
     "message": "Sorry!",
     "description": "Notification header for when something bad happened while processing a template."
+  },
+  "result_bad_xpath_description": {
+    "message": "There was a problem parsing an XPath expression.",
+    "description": "Notification for when an error occurs when parsing XPath expressions while processing a template."
   },
   "result_good_description": {
     "message": "$TEMPLATE$ has been copied",

--- a/chrome/bin/lib/background.js
+++ b/chrome/bin/lib/background.js
@@ -1384,7 +1384,7 @@
         }
         map[placeholder] = result;
       }
-      return callback(error ? new AppError('result_bad_xpath_description') : void 0);
+      return callback(error ? new AppError('result_bad_expression_description') : void 0);
     });
   };
 

--- a/chrome/bin/lib/background.js
+++ b/chrome/bin/lib/background.js
@@ -4,7 +4,7 @@
 // For all details and documentation:
 // <http://neocotic.com/template>
 (function() {
-  var AppError, BLACKLIST, DEFAULT_TEMPLATES, EXTENSION_ID, Extension, HOMEPAGE_DOMAIN, Icon, OPERATING_SYSTEMS, POPUP_DELAY, REAL_EXTENSION_ID, R_SELECT_TAG, R_UPPER_CASE, R_VALID_URL, SHORTENERS, SUPPORT, UNKNOWN_LOCALE, addAdditionalData, browser, buildConfig, buildDerivedData, buildIcons, buildPopup, buildStandardData, buildTemplate, callUrlShortener, deriveMessageInfo, deriveMessageTempate, executeScriptsInExistingWindows, ext, getActiveUrlShortener, getBrowserVersion, getHotkeys, getOperatingSystem, getTemplateWithKey, getTemplateWithMenuId, getTemplateWithShortcut, initStatistics, initTemplate, initTemplates, initTemplates_update, initToolbar, initToolbar_update, initUrlShorteners, initUrlShorteners_update, init_update, isBlacklisted, isExtensionActive, isNewInstall, isProductionBuild, isProtectedPage, isSpecialPage, isWebStore, nullIfEmpty, onMessage, onMessageExternal, operatingSystem, runSelectors, selectOrCreateTab, showNotification, transformData, updateHotkeys, updateProgress, updateStatistics, updateTemplateUsage, updateUrlShortenerUsage, _ref,
+  var AppError, BLACKLIST, DEFAULT_TEMPLATES, EXTENSION_ID, Extension, HOMEPAGE_DOMAIN, Icon, OPERATING_SYSTEMS, POPUP_DELAY, REAL_EXTENSION_ID, R_EXPRESION_TAG, R_UPPER_CASE, R_VALID_URL, SHORTENERS, SUPPORT, UNKNOWN_LOCALE, addAdditionalData, browser, buildConfig, buildDerivedData, buildIcons, buildPopup, buildStandardData, buildTemplate, callUrlShortener, deriveMessageInfo, deriveMessageTempate, evaluateExpressions, executeScriptsInExistingWindows, ext, getActiveUrlShortener, getBrowserVersion, getHotkeys, getOperatingSystem, getTemplateWithKey, getTemplateWithMenuId, getTemplateWithShortcut, initStatistics, initTemplate, initTemplates, initTemplates_update, initToolbar, initToolbar_update, initUrlShorteners, initUrlShorteners_update, init_update, isBlacklisted, isExtensionActive, isNewInstall, isProductionBuild, isProtectedPage, isSpecialPage, isWebStore, nullIfEmpty, onMessage, onMessageExternal, operatingSystem, selectOrCreateTab, showNotification, transformData, updateHotkeys, updateProgress, updateStatistics, updateTemplateUsage, updateUrlShortenerUsage, _ref,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
@@ -105,7 +105,7 @@
 
   POPUP_DELAY = 600;
 
-  R_SELECT_TAG = /^select(all)?(\S*)?$/;
+  R_EXPRESION_TAG = /^(select|xpath)(all)?(\S*)?$/;
 
   R_UPPER_CASE = /[A-Z]+/;
 
@@ -522,7 +522,7 @@
             if (tag === 'shorten' && !text) {
               text = this.url;
             }
-            trim = text.trim();
+            trim = (text != null ? text.trim() : void 0) || '';
             log.debug("Following is the contents of a " + tag + " tag...", text);
             if (!trim || tag === 'shorten' && !R_VALID_URL.test(trim)) {
               return text;
@@ -583,13 +583,13 @@
           return done();
         });
       }, function(done) {
-        var info, match, placeholder, selectMap, shortenMap;
+        var expressionMap, info, match, placeholder, shortenMap;
 
         updateProgress(70);
         if (_.isEmpty(placeholders)) {
           return done();
         }
-        selectMap = {};
+        expressionMap = {};
         shortenMap = {};
         for (placeholder in placeholders) {
           if (!__hasProp.call(placeholders, placeholder)) continue;
@@ -597,31 +597,36 @@
           if (info.tag === 'shorten') {
             shortenMap[placeholder] = info.data;
           } else {
-            match = info.tag.match(R_SELECT_TAG);
-            selectMap[placeholder] = {
-              all: match[1] != null,
-              convertTo: match[2],
-              selector: info.data
-            };
+            match = info.tag.match(R_EXPRESION_TAG);
+            if (match) {
+              expressionMap[placeholder] = {
+                all: match[2] != null,
+                convertTo: match[3],
+                expression: info.data,
+                type: match[1]
+              };
+            }
           }
         }
         return async.series([
           function(done) {
             updateProgress(80);
-            if (_.isEmpty(selectMap)) {
+            if (_.isEmpty(expressionMap)) {
               return done();
             }
-            return runSelectors(active, selectMap, function() {
+            return evaluateExpressions(active, expressionMap, function(err) {
               var value;
 
               updateProgress(85);
-              log.info("" + (_.size(selectMap)) + " selector(s) were executed");
-              for (placeholder in selectMap) {
-                if (!__hasProp.call(selectMap, placeholder)) continue;
-                value = selectMap[placeholder];
-                placeholders[placeholder] = value;
+              if (!err) {
+                log.info("" + (_.size(expressionMap)) + " expression(s) were evaluated");
+                for (placeholder in expressionMap) {
+                  if (!__hasProp.call(expressionMap, placeholder)) continue;
+                  value = expressionMap[placeholder];
+                  placeholders[placeholder] = value;
+                }
               }
-              return done();
+              return done(err);
             });
           }, function(done) {
             updateProgress(90);
@@ -659,7 +664,7 @@
       type = utils.capitalize(message.type);
       analytics.track('Requests', 'Processed', type, shortcut ? message.data.key.charCodeAt(0) : void 0);
       if (!err && !output) {
-        err = new Error(i18n.get('result_bad_empty_description', template.title));
+        err = new AppError('result_bad_empty_description', template.title);
       }
       notification = ext.notification;
       if (err) {
@@ -865,9 +870,7 @@
       var messageKey, substitutions;
 
       messageKey = arguments[0], substitutions = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-      if (messageKey) {
-        this.message = i18n.get(messageKey, substitutions);
-      }
+      Error.call(this, messageKey ? i18n.get(messageKey, substitutions) : void 0);
     }
 
     return AppError;
@@ -1266,6 +1269,24 @@
       },
       url: url.attr('source'),
       version: ext.version,
+      xpath: function() {
+        return getCallback('xpath');
+      },
+      xpathall: function() {
+        return getCallback('xpathall');
+      },
+      xpathallhtml: function() {
+        return getCallback('xpathallhtml');
+      },
+      xpathallmarkdown: function() {
+        return getCallback('xpathallmarkdown');
+      },
+      xpathhtml: function() {
+        return getCallback('xpathhtml');
+      },
+      xpathmarkdown: function() {
+        return getCallback('xpathmarkdown');
+      },
       yourls: yourls.enabled,
       yourlsauthentication: yourls.authentication,
       yourlspassword: yourls.password,
@@ -1329,7 +1350,7 @@
     return template;
   };
 
-  runSelectors = function(tab, map, callback) {
+  evaluateExpressions = function(tab, map, callback) {
     var placeholder;
 
     log.trace();
@@ -1341,22 +1362,29 @@
       return callback();
     }
     return chrome.tabs.sendMessage(tab.id, {
-      selectors: map
+      expressions: map
     }, function(response) {
-      var result, selector, _ref;
+      var convertTo, error, expression, result, _ref;
 
       log.debug('The following response was returned by the content script...', response);
-      _ref = response.selectors;
+      _ref = response.expressions;
       for (placeholder in _ref) {
         if (!__hasProp.call(_ref, placeholder)) continue;
-        selector = _ref[placeholder];
-        result = selector.result || '';
+        expression = _ref[placeholder];
+        convertTo = expression.convertTo, error = expression.error, result = expression.result;
+        if (error) {
+          break;
+        }
+        result || (result = '');
         if (_.isArray(result)) {
           result = result.join('\n');
         }
-        map[placeholder] = selector.convertTo === 'markdown' ? md(result) : result;
+        if (convertTo === 'markdown') {
+          result = md(result);
+        }
+        map[placeholder] = result;
       }
-      return callback();
+      return callback(error ? new AppError('result_bad_xpath_description') : void 0);
     });
   };
 
@@ -1992,7 +2020,7 @@
     oauth = false;
     title = service.title;
     if (!endpoint) {
-      return callback(new Error(i18n.get('shortener_config_error', title)));
+      return callback(new AppError('shortener_config_error', title));
     }
     tasks = [];
     _.each(map, function(url, placeholder) {
@@ -2030,7 +2058,7 @@
                   map[placeholder] = service.output(xhr.responseText);
                   return done();
                 } else {
-                  return done(new Error(i18n.get('shortener_detailed_error', [title, url])));
+                  return done(new AppError('shortener_detailed_error', title, url));
                 }
               }
             };

--- a/chrome/bin/lib/background.js
+++ b/chrome/bin/lib/background.js
@@ -4,7 +4,7 @@
 // For all details and documentation:
 // <http://neocotic.com/template>
 (function() {
-  var AppError, BLACKLIST, DEFAULT_TEMPLATES, EXTENSION_ID, Extension, HOMEPAGE_DOMAIN, Icon, OPERATING_SYSTEMS, POPUP_DELAY, REAL_EXTENSION_ID, R_EXPRESION_TAG, R_UPPER_CASE, R_VALID_URL, SHORTENERS, SUPPORT, UNKNOWN_LOCALE, addAdditionalData, browser, buildConfig, buildDerivedData, buildIcons, buildPopup, buildStandardData, buildTemplate, callUrlShortener, deriveMessageInfo, deriveMessageTempate, evaluateExpressions, executeScriptsInExistingWindows, ext, getActiveUrlShortener, getBrowserVersion, getHotkeys, getOperatingSystem, getTemplateWithKey, getTemplateWithMenuId, getTemplateWithShortcut, initStatistics, initTemplate, initTemplates, initTemplates_update, initToolbar, initToolbar_update, initUrlShorteners, initUrlShorteners_update, init_update, isBlacklisted, isExtensionActive, isNewInstall, isProductionBuild, isProtectedPage, isSpecialPage, isWebStore, nullIfEmpty, onMessage, onMessageExternal, operatingSystem, selectOrCreateTab, showNotification, transformData, updateHotkeys, updateProgress, updateStatistics, updateTemplateUsage, updateUrlShortenerUsage, _ref,
+  var AppError, BLACKLIST, DEFAULT_TEMPLATES, EXTENSION_ID, Extension, HOMEPAGE_DOMAIN, Icon, OPERATING_SYSTEMS, POPUP_DELAY, REAL_EXTENSION_ID, R_EXPRESSION_TAG, R_UPPER_CASE, R_VALID_URL, SHORTENERS, SUPPORT, UNKNOWN_LOCALE, addAdditionalData, browser, buildConfig, buildDerivedData, buildIcons, buildPopup, buildStandardData, buildTemplate, callUrlShortener, deriveMessageInfo, deriveMessageTempate, evaluateExpressions, executeScriptsInExistingWindows, ext, getActiveUrlShortener, getBrowserVersion, getHotkeys, getOperatingSystem, getTemplateWithKey, getTemplateWithMenuId, getTemplateWithShortcut, initStatistics, initTemplate, initTemplates, initTemplates_update, initToolbar, initToolbar_update, initUrlShorteners, initUrlShorteners_update, init_update, isBlacklisted, isExtensionActive, isNewInstall, isProductionBuild, isProtectedPage, isSpecialPage, isWebStore, nullIfEmpty, onMessage, onMessageExternal, operatingSystem, selectOrCreateTab, showNotification, transformData, updateHotkeys, updateProgress, updateStatistics, updateTemplateUsage, updateUrlShortenerUsage, _ref,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
@@ -105,7 +105,7 @@
 
   POPUP_DELAY = 600;
 
-  R_EXPRESION_TAG = /^(select|xpath)(all)?(\S*)?$/;
+  R_EXPRESSION_TAG = /^(select|xpath)(all)?(\S*)?$/;
 
   R_UPPER_CASE = /[A-Z]+/;
 
@@ -597,7 +597,7 @@
           if (info.tag === 'shorten') {
             shortenMap[placeholder] = info.data;
           } else {
-            match = info.tag.match(R_EXPRESION_TAG);
+            match = info.tag.match(R_EXPRESSION_TAG);
             if (match) {
               expressionMap[placeholder] = {
                 all: match[2] != null,
@@ -870,7 +870,9 @@
       var messageKey, substitutions;
 
       messageKey = arguments[0], substitutions = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-      Error.call(this, messageKey ? i18n.get(messageKey, substitutions) : void 0);
+      if (messageKey) {
+        this.message = i18n.get(messageKey, substitutions);
+      }
     }
 
     return AppError;
@@ -1367,6 +1369,9 @@
       var convertTo, error, expression, result, _ref;
 
       log.debug('The following response was returned by the content script...', response);
+      if (response == null) {
+        response = {};
+      }
       _ref = response.expressions;
       for (placeholder in _ref) {
         if (!__hasProp.call(_ref, placeholder)) continue;

--- a/chrome/bin/pages/options.html
+++ b/chrome/bin/pages/options.html
@@ -1218,6 +1218,54 @@
                             <td i18n-content="opt_guide_argument_text_text"></td>
                             <td i18n-content="opt_guide_operations_upper_case_text"></td>
                           </tr>
+                          <tr>
+                            <td>xpath <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAll <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAllHTML <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_html_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAllMarkdown <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_markdown_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathHTML <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_html_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathMarkdown <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_markdown_text"></td>
+                          </tr>
                         </tbody>
                         <tfoot>
                           <tr>
@@ -1225,6 +1273,7 @@
                               <ul class="unstyled tight-bottom">
                                 <li><a data-goto="#guide_operations_ref_1" id="guide_operations_ref_1" class="ref-link">&sup1;</a> <em i18n-content="opt_guide_definitions_footer_1"></em></li>
                                 <li><a data-goto="#guide_operations_ref_2" id="guide_operations_ref_2" class="ref-link">&sup2;</a> <em i18n-content="opt_guide_definitions_footer_3"></em></li>
+                                <li><a data-goto="#guide_operations_ref_3" id="guide_operations_ref_3" class="ref-link">&sup3;</a> <em i18n-content="opt_guide_definitions_footer_4"></em></li>
                               </ul>
                             </td>
                           </tr>

--- a/chrome/src/_locales/en/messages.json
+++ b/chrome/src/_locales/en/messages.json
@@ -867,7 +867,7 @@
         "content": "</a>",
         "example": "</a>"
       },
-      "o_link_selectors": {
+      "o_link_xpath": {
         "content": "<a href=\"http://www.w3.org/TR/xpath/\" target=\"_blank\">",
         "example": "<a href=\"http://www.w3.org/TR/xpath/\">"
       }
@@ -2162,7 +2162,7 @@
     "description": "Description of the upperCase variable on the Guide tab of the Options page under the Operations section."
   },
   "opt_guide_operations_xpath_all_html_text": {
-    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all results for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathAllHTML variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_abbr": {
@@ -2188,7 +2188,7 @@
     }
   },
   "opt_guide_operations_xpath_all_markdown_text": {
-    "message": "Concatenate the contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "message": "Concatenate the contents of all results for the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
     "description": "Description of the xpathAllMarkdown variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2206,7 +2206,7 @@
     }
   },
   "opt_guide_operations_xpath_all_text": {
-    "message": "Concatenate the text of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Concatenate all results for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathAll variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2220,7 +2220,7 @@
     }
   },
   "opt_guide_operations_xpath_html_text": {
-    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression",
     "description": "Description of the xpathHTML variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_abbr": {
@@ -2246,7 +2246,7 @@
     }
   },
   "opt_guide_operations_xpath_markdown_text": {
-    "message": "Get the contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "message": "Get the contents of the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
     "description": "Description of the xpathMarkdown variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -2264,7 +2264,7 @@
     }
   },
   "opt_guide_operations_xpath_text": {
-    "message": "Get the text of first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "message": "Get the first result for the $O_LINK_XPATH$XPath$C_LINK$ expression as text",
     "description": "Description of the xpath variable on the Guide tab of the Options page under the Operations section.",
     "placeholders": {
       "c_link": {
@@ -3963,6 +3963,10 @@
     "message": "An error occurred while collecting information",
     "description": "Notification for when something went wrong while collecting contextual data before processing a template."
   },
+  "result_bad_expression_description": {
+    "message": "There was a problem parsing an expression.",
+    "description": "Notification for when an error occurs when parsing CSS selector or XPath expressions while processing a template."
+  },
   "result_bad_template_description": {
     "message": "An error occurred while deriving the activated template",
     "description": "Notification for when no active template can be derived from the current context."
@@ -3971,17 +3975,13 @@
     "message": "An error occurred while requesting information",
     "description": "Notification for when an invalid type was used by the requesting message."
   },
-  "result_bad_uri_description": {
-    "message": "The URL is not properly encoded",
-    "description": "Notification for when collecting data for an invalid URL before processing a template."
-  },
   "result_bad_title": {
     "message": "Sorry!",
     "description": "Notification header for when something bad happened while processing a template."
   },
-  "result_bad_xpath_description": {
-    "message": "There was a problem parsing an XPath expression.",
-    "description": "Notification for when an error occurs when parsing XPath expressions while processing a template."
+  "result_bad_uri_description": {
+    "message": "The URL is not properly encoded",
+    "description": "Notification for when collecting data for an invalid URL before processing a template."
   },
   "result_good_description": {
     "message": "$TEMPLATE$ has been copied",

--- a/chrome/src/_locales/en/messages.json
+++ b/chrome/src/_locales/en/messages.json
@@ -859,6 +859,20 @@
       }
     }
   },
+  "opt_guide_definitions_footer_4": {
+    "message": "Learn more about the $O_LINK_XPATH$XPath API$C_LINK$",
+    "description": "Fourth optional footer displayed below Definitions tables.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_selectors": {
+        "content": "<a href=\"http://www.w3.org/TR/xpath/\" target=\"_blank\">",
+        "example": "<a href=\"http://www.w3.org/TR/xpath/\">"
+      }
+    }
+  },
   "opt_guide_description_header": {
     "message": "Description",
     "description": "Header for the Description column."
@@ -2146,6 +2160,122 @@
   "opt_guide_operations_upper_case_text": {
     "message": "Transform the text provided into upper case",
     "description": "Description of the upperCase variable on the Guide tab of the Options page under the Operations section."
+  },
+  "opt_guide_operations_xpath_all_html_text": {
+    "message": "Concatenate the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathAllHTML variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_abbr": {
+        "content": "</abbr>",
+        "example": "</abbr>"
+      },
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_abbr_1": {
+        "content": "<abbr title=\"",
+        "example": "<abbr title=\""
+      },
+      "o_abbr_2": {
+        "content": "\">",
+        "example": "\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_all_markdown_text": {
+    "message": "Concatenate the contents of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "description": "Description of the xpathAllMarkdown variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_markdown": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/Markdown\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/Markdown\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_all_text": {
+    "message": "Concatenate the text of all elements matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathAll variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_html_text": {
+    "message": "Get the $O_ABBR_1$HyperText Markup Language$O_ABBR_2$HTML$C_ABBR$ contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpathHTML variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_abbr": {
+        "content": "</abbr>",
+        "example": "</abbr>"
+      },
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_abbr_1": {
+        "content": "<abbr title=\"",
+        "example": "<abbr title=\""
+      },
+      "o_abbr_2": {
+        "content": "\">",
+        "example": "\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_markdown_text": {
+    "message": "Get the contents of the first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression as $O_LINK_MARKDOWN$Markdown$C_LINK$",
+    "description": "Description of the xpathMarkdown variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_markdown": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/Markdown\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/Markdown\">"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
+  },
+  "opt_guide_operations_xpath_text": {
+    "message": "Get the text of first element matching the $O_LINK_XPATH$XPath$C_LINK$ expression",
+    "description": "Description of the xpath variable on the Guide tab of the Options page under the Operations section.",
+    "placeholders": {
+      "c_link": {
+        "content": "</a>",
+        "example": "</a>"
+      },
+      "o_link_xpath": {
+        "content": "<a href=\"http://en.wikipedia.org/wiki/XPath\" target=\"_blank\">",
+        "example": "<a href=\"http://en.wikipedia.org/wiki/XPath\">"
+      }
+    }
   },
   "opt_guide_options_header": {
     "message": "Options",
@@ -3848,6 +3978,10 @@
   "result_bad_title": {
     "message": "Sorry!",
     "description": "Notification header for when something bad happened while processing a template."
+  },
+  "result_bad_xpath_description": {
+    "message": "There was a problem parsing an XPath expression.",
+    "description": "Notification for when an error occurs when parsing XPath expressions while processing a template."
   },
   "result_good_description": {
     "message": "$TEMPLATE$ has been copied",

--- a/chrome/src/lib/background.coffee
+++ b/chrome/src/lib/background.coffee
@@ -100,8 +100,9 @@ OPERATING_SYSTEMS = [
 ]
 # Milliseconds before the popup automatically resets or closes, depending on user preferences.
 POPUP_DELAY       = 600
-# Regular expression used to extract useful information from `select` tag name variations.
-R_SELECT_TAG      = /^select(all)?(\S*)?$/
+# Regular expression used to extract useful information from different variations of names for tags
+# that are evaluated/executed later.
+R_EXPRESION_TAG   = /^(select|xpath)(all)?(\S*)?$/
 # Regular expression used to detect upper case characters.
 R_UPPER_CASE      = /[A-Z]+/
 # Very primitive regular expression used to perform simple URL validation.
@@ -435,7 +436,7 @@ onMessage = (message, sender, sendResponse) ->
         (text, render) ->
           text = render text if text
           text = @url        if tag is 'shorten' and not text
-          trim = text.trim()
+          trim = text?.trim() or ''
           log.debug "Following is the contents of a #{tag} tag...", text
 
           # If `trim` doesn't appear to be a valid so just return the rendered `text`.
@@ -516,36 +517,40 @@ onMessage = (message, sender, sendResponse) ->
       return do done if _.isEmpty placeholders
 
       # Maps to populated with relevant data derived from their related stored placeholders.
-      selectMap  = {}
-      shortenMap = {}
+      expressionMap = {}
+      shortenMap    = {}
 
       for own placeholder, info of placeholders
         if info.tag is 'shorten'
           shortenMap[placeholder] = info.data
         else
-          match = info.tag.match R_SELECT_TAG
-          selectMap[placeholder] =
-            all:       match[1]?
-            convertTo: match[2]
-            selector:  info.data
+          match = info.tag.match R_EXPRESION_TAG
+          if match
+            expressionMap[placeholder] =
+              all:        match[2]?
+              convertTo:  match[3]
+              expression: info.data
+              type:       match[1]
 
       async.series [
         (done) ->
           updateProgress 80
 
-          # Only proceed if any *select* placeholders were used.
-          return do done if _.isEmpty selectMap
+          # Only proceed if any expression (e.g. *select*, *xpath*) placeholders were used.
+          return do done if _.isEmpty expressionMap
 
-          # Execute all selectors within the `active` tab and update `selectMap` with the results.
-          runSelectors active, selectMap, ->
+          # Evaluate all of the expressions within the `active` tab and update `expressionMap` with
+          # the results.
+          evaluateExpressions active, expressionMap, (err) ->
             updateProgress 85
 
-            log.info "#{_.size selectMap} selector(s) were executed"
+            unless err
+              log.info "#{_.size expressionMap} expression(s) were evaluated"
 
-            # Update the corresponding placeholders with their result.
-            placeholders[placeholder] = value for own placeholder, value of selectMap
+              # Update the corresponding placeholders with their result.
+              placeholders[placeholder] = value for own placeholder, value of expressionMap
 
-            do done
+            done err
 
         (done) ->
           updateProgress 90
@@ -587,7 +592,7 @@ onMessage = (message, sender, sendResponse) ->
     # Ensure that the user is notified if they have attempted to copy an empty string to the system
     # clipboard.
     if not err and not output
-      err = new Error i18n.get 'result_bad_empty_description', template.title
+      err = new AppError 'result_bad_empty_description', template.title
 
     notification = ext.notification
 
@@ -793,8 +798,7 @@ class AppError extends Error
 
   # Create a new instance of `AppError` with a localized message.
   constructor: (messageKey, substitutions...) ->
-    if messageKey
-      @message = i18n.get messageKey, substitutions
+    Error.call this, if messageKey then i18n.get messageKey, substitutions
 
 # Data functions
 # --------------
@@ -1109,6 +1113,18 @@ buildStandardData = (tab, getCallback) ->
         render(text).toUpperCase()
     url:                   url.attr 'source'
     version:               ext.version
+    xpath:                ->
+      getCallback 'xpath'
+    xpathall:             ->
+      getCallback 'xpathall'
+    xpathallhtml:         ->
+      getCallback 'xpathallhtml'
+    xpathallmarkdown:     ->
+      getCallback 'xpathallmarkdown'
+    xpathhtml:            ->
+      getCallback 'xpathhtml'
+    xpathmarkdown:        ->
+      getCallback 'xpathmarkdown'
     yourls:                yourls.enabled
     yourlsauthentication:  yourls.authentication
     yourlspassword:        yourls.password
@@ -1152,10 +1168,12 @@ deriveMessageTempate = (message) ->
 
   template
 
-# Run the selectors in `map` within the content scripts in `tab` in order to obtain their
+# Evaluate the expressions in `map` within the content scripts in `tab` in order to obtain their
 # corresponding values.  
-# `callback` will be called with the result once all the selectors have been run.
-runSelectors = (tab, map, callback) ->
+# Expressions can be of mixed type (i.e. CSS selector, XPath expression) and contain different
+# instructions depending on the tag that was used by the user.  
+# `callback` will be called with the result once all of the expressions have been evaluated.
+evaluateExpressions = (tab, map, callback) ->
   log.trace()
 
   # Since content scripts cannot be executed on *protected* pages attempting to send a message to
@@ -1165,17 +1183,23 @@ runSelectors = (tab, map, callback) ->
     map[placeholder] = '' for own placeholder of map
     return do callback
 
-  # Tell the content script in `tab` to run all of the selectors in `map` and update it with their
-  # corresponding values.
-  chrome.tabs.sendMessage tab.id, selectors: map, (response) ->
+  # Tell the content script in `tab` to evaluate all of the expressions in `map` and update it with
+  # their corresponding values.
+  chrome.tabs.sendMessage tab.id, expressions: map, (response) ->
     log.debug 'The following response was returned by the content script...', response
 
-    for own placeholder, selector of response.selectors
-      result = selector.result or ''
-      result = result.join '\n' if _.isArray result
-      map[placeholder] = if selector.convertTo is 'markdown' then md result else result
+    for own placeholder, expression of response.expressions
+      {convertTo, error, result} = expression
 
-    do callback
+      break if error
+
+      result or= ''
+      result   = result.join '\n' if _.isArray result
+      result   = md result if convertTo is 'markdown'
+
+      map[placeholder] = result
+
+    callback if error then new AppError 'result_bad_xpath_description'
 
 # Ensure there is a lower case variant of all properties of `data`, optionally removing the
 # original non-lower-case property.
@@ -1648,7 +1672,7 @@ callUrlShortener = (map, callback) ->
   title    = service.title
 
   # Ensure the service URL exists in case it is user-defined (e.g. YOURLS).
-  return callback new Error i18n.get 'shortener_config_error', title unless endpoint
+  return callback new AppError 'shortener_config_error', title unless endpoint
 
   tasks = []
   _.each map, (url, placeholder) ->
@@ -1684,7 +1708,7 @@ callUrlShortener = (map, callback) ->
                 do done
               else
                 # Something went wrong so let's tell the user.
-                done new Error i18n.get 'shortener_detailed_error', [title, url]
+                done new AppError 'shortener_detailed_error', title, url
 
           # Finally, send the HTTP request.
           xhr.send service.input url

--- a/chrome/src/lib/background.coffee
+++ b/chrome/src/lib/background.coffee
@@ -1199,7 +1199,7 @@ evaluateExpressions = (tab, map, callback) ->
 
       map[placeholder] = result
 
-    callback if error then new AppError 'result_bad_xpath_description'
+    callback if error then new AppError 'result_bad_expression_description'
 
 # Ensure there is a lower case variant of all properties of `data`, optionally removing the
 # original non-lower-case property.

--- a/chrome/src/lib/background.coffee
+++ b/chrome/src/lib/background.coffee
@@ -102,7 +102,7 @@ OPERATING_SYSTEMS = [
 POPUP_DELAY       = 600
 # Regular expression used to extract useful information from different variations of names for tags
 # that are evaluated/executed later.
-R_EXPRESION_TAG   = /^(select|xpath)(all)?(\S*)?$/
+R_EXPRESSION_TAG  = /^(select|xpath)(all)?(\S*)?$/
 # Regular expression used to detect upper case characters.
 R_UPPER_CASE      = /[A-Z]+/
 # Very primitive regular expression used to perform simple URL validation.
@@ -524,7 +524,7 @@ onMessage = (message, sender, sendResponse) ->
         if info.tag is 'shorten'
           shortenMap[placeholder] = info.data
         else
-          match = info.tag.match R_EXPRESION_TAG
+          match = info.tag.match R_EXPRESSION_TAG
           if match
             expressionMap[placeholder] =
               all:        match[2]?
@@ -798,7 +798,7 @@ class AppError extends Error
 
   # Create a new instance of `AppError` with a localized message.
   constructor: (messageKey, substitutions...) ->
-    Error.call this, if messageKey then i18n.get messageKey, substitutions
+    @message = i18n.get messageKey, substitutions if messageKey
 
 # Data functions
 # --------------
@@ -1187,6 +1187,8 @@ evaluateExpressions = (tab, map, callback) ->
   # their corresponding values.
   chrome.tabs.sendMessage tab.id, expressions: map, (response) ->
     log.debug 'The following response was returned by the content script...', response
+
+    response ?= {}
 
     for own placeholder, expression of response.expressions
       {convertTo, error, result} = expression

--- a/chrome/src/pages/options.html
+++ b/chrome/src/pages/options.html
@@ -1218,6 +1218,54 @@
                             <td i18n-content="opt_guide_argument_text_text"></td>
                             <td i18n-content="opt_guide_operations_upper_case_text"></td>
                           </tr>
+                          <tr>
+                            <td>xpath <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAll <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAllHTML <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_html_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathAllMarkdown <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_all_markdown_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathHTML <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_html_text"></td>
+                          </tr>
+                          <tr>
+                            <td>xpathMarkdown <a data-goto="#guide_operations_ref_1" class="ref-link">&sup1;</a><span class="label label-success pull-right" i18n-content="opt_guide_new_text"></span></td>
+                            <td>
+                              <span i18n-content="opt_guide_argument_text_text"></span>
+                              <a data-goto="#guide_operations_ref_3" class="ref-link">&sup3;</a>
+                            </td>
+                            <td i18n-content="opt_guide_operations_xpath_markdown_text"></td>
+                          </tr>
                         </tbody>
                         <tfoot>
                           <tr>
@@ -1225,6 +1273,7 @@
                               <ul class="unstyled tight-bottom">
                                 <li><a data-goto="#guide_operations_ref_1" id="guide_operations_ref_1" class="ref-link">&sup1;</a> <em i18n-content="opt_guide_definitions_footer_1"></em></li>
                                 <li><a data-goto="#guide_operations_ref_2" id="guide_operations_ref_2" class="ref-link">&sup2;</a> <em i18n-content="opt_guide_definitions_footer_3"></em></li>
+                                <li><a data-goto="#guide_operations_ref_3" id="guide_operations_ref_3" class="ref-link">&sup3;</a> <em i18n-content="opt_guide_definitions_footer_4"></em></li>
                               </ul>
                             </td>
                           </tr>


### PR DESCRIPTION
Added the following template operations:
- xpath
- xpathAll
- xpathAllHTML
- xpathAllMarkdown
- xpathHTML
- xpathMarkdown

Currently these exactly match the `select\*` equivalents. This feature is being added in response to #181.

This implementation only supports XPath for matching elements, so expressions like `count(//p)` won't work and will cause the template copy to fail. I'm interesting in hearing if this functionality would be wanted to and I can make the implementation more sophisticated (which I kind of want to do anyway).
