### PR TITLE
Update YOURLS wiki link

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -3988,8 +3988,8 @@
         "example": "</a>"
       },
       "o_link_api_docs": {
-        "content": "<a href=\"http://code.google.com/p/yourls/wiki/PasswordlessAPI\" target=\"_blank\">",
-        "example": "<a href=\"http://code.google.com/p/yourls/wiki/PasswordlessAPI\">"
+        "content": "<a href=\"http://yourls.org/passwordlessapi\" target=\"_blank\">",
+        "example": "<a href=\"http://yourls.org/passwordlessapi\">"
       }
     }
   },


### PR DESCRIPTION
Wiki is now on GitHub. Make it simple by switch to the official link.

Duplicate #205
