### PR TITLE
Fix #209 redirecting back to extension pages is blocked by chrome

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
 # Authors ordered by first contribution
 
 * Alasdair Mercer <mercer.alasdair@gmail.com>
+* Jethro Yu <comet.jc@gmail.com>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,6 +32,9 @@
           , "run_at": "document_start"
         }
     ]
+  ,  "web_accessible_resources": [
+        "pages/oauth2.html"
+    ]
   , "content_security_policy": "script-src 'self' 'unsafe-eval' https://ssl.google-analytics.com https://*.uservoice.com; object-src 'self'"
   , "default_locale": "en"
   , "description": "__MSG_description__"


### PR DESCRIPTION
Fix #209 redirecting back to extension pages is blocked by chrome
